### PR TITLE
Change Diasporial reference and link to tutorials on the project site

### DIFF
--- a/app/views/pages/get_involved.html.erb
+++ b/app/views/pages/get_involved.html.erb
@@ -132,7 +132,7 @@
             <%= t '.support_ex2' %></a>.
         </li>
         <li>
-          <%= t('.support_ex3', diasporial_link: link_to('Diasporial', 'http://diasporial.com/tutorials/')).html_safe %>
+          <%= t('.support_ex3', tutorials_link: link_to('diaspora* tutorials', 'https://diasporafoundation.org/tutorials')).html_safe %>
         </li>
         <li>
           <%= t('.support_ex4', irc_channel_link: link_to(t('.irc_channel_link_text'), 'http://webchat.freenode.net/?channels=diaspora')).html_safe %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -170,7 +170,7 @@ en:
       support_header: "Provide support"
       support_ex1: "Help new users feel welcome!"
       support_ex2: "Sign up here"
-      support_ex3: "Write user tutorials at %{diasporial_link}."
+      support_ex3: "Write user tutorials for the %{tutorials_link} section."
       support_ex4: 'Answer users’ questions on our %{irc_channel_link} or answer users’ questions on diaspora* itself by following the <span class="click">#help</span>, <span class="click">#question</span> and <span class="click">#feedback</span> hashtags.'
       irc_channel_link_text: "IRC channel"
       support_ex5: "Contribute to %{wiki_link}."


### PR DESCRIPTION
I noticed that there was still a link to Diasporial on https://diasporafoundation.org/get_involved

Have updated it to https://diasporafoundation.org/tutorials and changed the text accordingly.

Tested it locally, and text and link work fine.

Hope I have done the commit properly - been ages since I did any Git stuff. (I did `git status` and everything!)
