### PR TITLE
Moved NSFW explanation to ‘Profile’  rather than ‘Account’ section

### DIFF
--- a/app/views/pages/getting_started7.html.erb
+++ b/app/views/pages/getting_started7.html.erb
@@ -27,11 +27,11 @@
         
         <h5><%= t '.profile' %></h5>
         <p><%= t('.profile_ex', part1_link: link_to(t('pages.tutorials.part1'), sign_up_path)).html_safe %></p>
+        <p><%= t '.account_ex2' %></p>
+        <p><%= t('.account_ex3').html_safe %></p>
         
         <h5><%= t '.account' %></h5>
         <p><%= t '.account_ex1' %></p>
-        <p><%= t '.account_ex2' %></p>
-        <p><%= t('.account_ex3').html_safe %></p>
         <p><%= t '.account_ex4' %></p>
         
         <h5><%= t '.privacy' %></h5>


### PR DESCRIPTION
I have just noticed that the explanation of the 'NSFW' profile setting was under the Account tab. So I've moved it to the profile tab.

I have not renamed the paths of the two affected paragraphs ('account_ex2' and 'account_ex3'), even though they should now be renamed 'profile_ex2' and 'profile_ex3' because this would involve changing those path names in each localisation file.

However, if you think it would be better to change those names now, let me know and I'll do it.
