### PR TITLE
Fix missing text in getting_started7

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -494,9 +494,7 @@ en:
       privacy_ex: 'This is a list of users you are ignoring. You can remove them from this list if you want to start seeing posts from them again. See %{part5_link} for more on ignoring people.'
       services: 'Services'
       services_ex: 'The Services page shows your connected services (e.g. Facebook, Twitter, Tumblr) and allows you to connect new services to your diaspora* seed.'
-      finish1: 'Thanks a lot for reading this getting started guide! We hope it has been useful to you and that you now feel comfortable using diaspora* as your new online home. If you have any questions, feel free to make a public post on diaspora* including the '
-      finish2: ' and '
-      finish3: ' tags so that other community members can try to help you. There’s a wonderful, generous community out there!'
+      finish1: 'Thanks a lot for reading this getting started guide! We hope it has been useful to you and that you now feel comfortable using diaspora* as your new online home. If you have any questions, feel free to make a public post on diaspora* including the <span class="click">#help</span> and <span class="click">#question</click> tags so that other community members can try to help you. There’s a wonderful, generous community out there!'
     formatting:
       byline: 'Formatting text'
       menu_title: 'Formatting text'


### PR DESCRIPTION
Fixed the last line of the tutorial, as notified in https://github.com/diaspora/diaspora/issues/4857
