### PR TITLE
Removed extra comma in divs

### DIFF
--- a/app/views/pages/formatting.html.erb
+++ b/app/views/pages/formatting.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_title, t('.menu_title') %>
 <% content_for :wrapper_class, "index_page" %>
 
-<div id="masthead", class="hero">
+<div id="masthead" class="hero">
   <div class="container">
     <h1><%= t 'pages.tutorials.headline' %></h1>
     <h2><%= t '.byline' %></h2>

--- a/app/views/pages/getting_started1.html.erb
+++ b/app/views/pages/getting_started1.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_title, t('.menu_title') %>
 <% content_for :wrapper_class, "index_page" %>
 
-<div id="masthead", class="hero">
+<div id="masthead" class="hero">
   <div class="container">
     <h1><%= t 'pages.tutorials.started_head' %></h1>
     <h2><%= t '.byline' %></h2>

--- a/app/views/pages/getting_started2.html.erb
+++ b/app/views/pages/getting_started2.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_title, t('.menu_title') %>
 <% content_for :wrapper_class, "index_page" %>
 
-<div id="masthead", class="hero">
+<div id="masthead" class="hero">
   <div class="container">
     <h1><%= t 'pages.tutorials.started_head' %></h1>
     <h2><%= t '.byline' %></h2>

--- a/app/views/pages/getting_started3.html.erb
+++ b/app/views/pages/getting_started3.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_title, t('.menu_title') %>
 <% content_for :wrapper_class, "index_page" %>
 
-<div id="masthead", class="hero">
+<div id="masthead" class="hero">
   <div class="container">
     <h1><%= t 'pages.tutorials.started_head' %></h1>
     <h2><%= t '.byline' %></h2>

--- a/app/views/pages/getting_started4.html.erb
+++ b/app/views/pages/getting_started4.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_title, t('.menu_title') %>
 <% content_for :wrapper_class, "index_page" %>
 
-<div id="masthead", class="hero">
+<div id="masthead" class="hero">
   <div class="container">
     <h1><%= t 'pages.tutorials.started_head' %></h1>
     <h2><%= t '.byline' %></h2>

--- a/app/views/pages/getting_started5.html.erb
+++ b/app/views/pages/getting_started5.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_title, t('.menu_title') %>
 <% content_for :wrapper_class, "index_page" %>
 
-<div id="masthead", class="hero">
+<div id="masthead" class="hero">
   <div class="container">
     <h1><%= t 'pages.tutorials.started_head' %></h1>
     <h2><%= t '.byline' %></h2>

--- a/app/views/pages/getting_started6.html.erb
+++ b/app/views/pages/getting_started6.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_title, t('.menu_title') %>
 <% content_for :wrapper_class, "index_page" %>
 
-<div id="masthead", class="hero">
+<div id="masthead" class="hero">
   <div class="container">
     <h1><%= t 'pages.tutorials.started_head' %></h1>
     <h2><%= t '.byline' %></h2>

--- a/app/views/pages/getting_started7.html.erb
+++ b/app/views/pages/getting_started7.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_title, t('.menu_title') %>
 <% content_for :wrapper_class, "index_page" %>
 
-<div id="masthead", class="hero">
+<div id="masthead" class="hero">
   <div class="container">
     <h1><%= t 'pages.tutorials.started_head' %></h1>
     <h2><%= t '.byline' %></h2>

--- a/app/views/pages/other_docs.html.erb
+++ b/app/views/pages/other_docs.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_title, t('.menu_title') %>
 <% content_for :wrapper_class, "index_page" %>
 
-<div id="masthead", class="hero">
+<div id="masthead" class="hero">
   <div class="container">
     <h1><%= t '.headline' %></h1>
     <h2><%= t '.byline' %></h2>

--- a/app/views/pages/tips.html.erb
+++ b/app/views/pages/tips.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_title, t('.menu_title') %>
 <% content_for :wrapper_class, "index_page" %>
 
-<div id="masthead", class="hero">
+<div id="masthead" class="hero">
   <div class="container">
     <h1><%= t '.headline' %></h1>
     <h2><%= t '.byline' %></h2>

--- a/app/views/pages/tutorials.html.erb
+++ b/app/views/pages/tutorials.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_title, t('.menu_title') %>
 <% content_for :wrapper_class, "index_page" %>
 
-<div id="masthead", class="hero">
+<div id="masthead" class="hero">
   <div class="container">
     <h1><%= t '.headline' %></h1>
     <h2><%= t '.byline' %></h2>


### PR DESCRIPTION
Removes comma from `<div id="masthead", class="hero">` ocurrences in tutorial pages.
