### PR TITLE
Add a donations page

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -56,7 +56,7 @@
         </div>
       </div>
       <div class="row">
-        <div class="col-md-3">
+        <div class="col-md-2">
           <ul>
             <li>
               <a href="https://github.com/diaspora/">
@@ -70,7 +70,7 @@
             </li>
           </ul>
         </div>
-        <div class="col-md-3">
+        <div class="col-md-2">
           <ul>
             <li>
               <a href="https://github.com/diaspora/diaspora/issues">
@@ -84,7 +84,7 @@
             </li>
           </ul>
         </div>
-        <div class="col-md-3">
+        <div class="col-md-2">
           <ul>
             <li>
               <a href="https://webchat.freenode.net/?channels=diaspora">
@@ -98,7 +98,14 @@
             </li>
           </ul>
         </div>
-        <div class="col-md-3">
+        <div class="col-md-2">
+          <ul>
+            <li>
+              <%= link_to t('.donations'), donations_url %>
+            </li>
+          </ul>
+        </div>
+        <div class="col-md-4">
           <div class="dropdown dropup">
             <button class="btn btn-defalt dropdown-toggle" data-toggle="dropdown">
               <%= t '.choose_language' %>

--- a/app/views/pages/donations.erb
+++ b/app/views/pages/donations.erb
@@ -1,0 +1,31 @@
+<% content_for :page_title, t('.menu_title') %>
+<% content_for :wrapper_class, 'index-page' %>
+
+<div id="masthead" class="hero">
+  <div class="container">
+    <h1><%= t '.headline' %></h1>
+    <h2 class="lead"><%= t '.byline' %></h2>
+  </div>
+</div>
+<div class="container">
+  <div class="row">
+    <div class="col-md-12">
+      <div class="page-header">
+        <h3><%= t '.help_your_podmin' %></h3>
+      </div>
+      <p><%= t '.help_your_podmin_details' %></p>
+    </div>
+  </div>
+</div>
+<div class="container">
+  <div class="row">
+    <div class="col-md-12">
+      <div id="donating" class="page-header">
+        <h3><%= t '.help_development' %></h3>
+      </div>
+      <p><%= t '.help_development_details' %></p>
+      <p><%= t('.bountysource_details', bountysource: link_to('Bountysource', 'https://www.bountysource.com/teams/diaspora'), bountysource_team_link: link_to(t('.bountysource_team_link_text'), 'https://www.bountysource.com/teams/diaspora')).html_safe %></p>
+      <p><%= t('.bountysource_more_info', bountysource_blogpost_link: link_to(t('.bountysource_blogpost_link_text'), 'https://blog.diasporafoundation.org/14-support-diaspora-development-via-bountysource')).html_safe %></p>
+      <p><%= t('.direct_donation', direct_donation_link: link_to(t('.direct_donation_link_text'), 'https://wiki.diasporafoundation.org/Donations#Directly_to_developers')).html_safe %></p>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,6 +25,7 @@ en:
       irc_development: "IRC - Development"
       discussion_general: "Discussion & support"
       discussion_development: "Discussion - Development"
+      donations: "Donations"
       choose_language: "Choose language"
       translate: "Add a translation"
       cc_license_alt: "Creative Commons License"
@@ -132,6 +133,20 @@ en:
       reshare_alt: Reshare
       mention_alt: Mention
       heart_alt: Heart
+    donations:
+      menu_title: "Donations"
+      headline: "Donate to diaspora*"
+      byline: "And help the network to grow!"
+      help_your_podmin: "Support the network by donating to your podmin"
+      help_your_podmin_details: "The administrators of the “pods” that make up the network are the people who bring diaspora* to life. But running a pod costs money. To help your podmin keep the server running and performing well, you can send them some money. Look for a “Donate” section in the left-hand column of the main stream. If your podmin has enabled payments through the app, you’ll find a list of the payment systems accepted by your podmin (Paypal, Liberapay and bitcoin are supported)."
+      help_development: "Help diaspora*’s development"
+      help_development_details: "diaspora* is developed by volunteers, but you can support their work by making donations in one of two ways:"
+      bountysource_details: "You can make donations towards individual tasks (GitHub issues) using %{bountysource}, for example to fix a bug that’s annoying you or to build a feature you would really like to see in diaspora*. When a developer completes a task and their work has been accepted by the diaspora* core team, they then get the money (the “bounty”) attached to that issue. This means that you can be a part of the development of diaspora* even if you don’t write code! Of course, if you want to support development but don’t have a specific issue in mind, you can give money to directly %{bountysource_team_link} and we will attach it ourselves depending on our priorities."
+      bountysource_team_link_text: "the diaspora* team"
+      bountysource_more_info: "See %{bountysource_blogpost_link} for more about how you can use Bountysource to support our development."
+      bountysource_blogpost_link_text: "this blog post"
+      direct_donation: "You can also support individual developers, some of whom do a lot of work towards improving diaspora* but don’t always work on open GitHub issues and so who would’t benefit from support via Bountysource. If you’re interesting in supporting the project this way, have a look at our wiki article on %{direct_donation_link}."
+      direct_donation_link_text: "how to directly support our developers"
     get_involved:
       headline: "Get involved!"
       byline: "The future of the social web starts with you"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ DiasporaProjectSite::Application.routes.draw do
   constraints subdomain: /^(|www)$/i do
     controller :pages do
       get :about
+      get :donations
       get :formatting
       get :get_involved
       get :other_docs


### PR DESCRIPTION
As planned I started to work on a donations page for the official website. I took the content from [the wiki page](https://wiki.diasporafoundation.org/Donations).

Here is how it looks at the moment:
![donations](https://user-images.githubusercontent.com/930064/29920815-9d6186a4-8e4f-11e7-9fa6-9da691e6f1cc.png)

Things to do:
- [ ] Probably some design, the page is very raw at the moment (style, images)
- [ ] Check the wording and make it more "marketing"
- [ ] Choose where we want to link that page. In the header? The footer? Elsewhere?
- [ ] Directly embed Liberapay donate buttons?
- [ ] Ask if other contributors want to be listed here.