### PR TITLE
Add support for error logging via Sentry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,8 @@ gem "feedjira",               github: "feedjira/feedjira"
 gem "trollop",                "2.1.2"
 gem "sanitize",               "4.0.1"
 
+gem "sentry-raven"
+
 group :development, :test do
   gem "pry"
   gem "awesome_print",   "1.7.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -234,6 +234,8 @@ GEM
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
     sax-machine (1.3.2)
+    sentry-raven (2.7.4)
+      faraday (>= 0.7.6, < 1.0)
     slop (3.6.0)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
@@ -289,6 +291,7 @@ DEPENDENCIES
   rspec-rails (= 3.4.2)
   sanitize (= 4.0.1)
   sass-rails (= 5.0.4)
+  sentry-raven
   trollop (= 2.1.2)
   turbolinks
   uglifier (= 3.0.0)
@@ -296,4 +299,4 @@ DEPENDENCIES
   will_paginate-bootstrap
 
 BUNDLED WITH
-   1.16.3
+   1.16.4

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,6 @@
+if ENV["SENTRY_DSN"]
+  Raven.configure do |config|
+    config.dsn = ENV["SENTRY_DSN"]
+    config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
+  end
+end


### PR DESCRIPTION
We did not catch https://github.com/diaspora/diaspora-project-site/pull/125#issuecomment-428214928 at all, and since this a pretty important asset for the project, it probably makes sense to add some kind of logging and alerting to our site...

Internal note:

* I will create accounts on my Sentry instance for the core team as soon as this is merged.
* I already set up the production env, so that deploying this will automatically start sending errors.