### PR TITLE
Fix mailing_list_link in getting_started

### DIFF
--- a/app/views/pages/get_involved.html.erb
+++ b/app/views/pages/get_involved.html.erb
@@ -63,6 +63,7 @@
         <%= t('.code_ex4',
           get_started_guide_link: link_to(t('.get_started_guide_link_text'), 'https://wiki.diasporafoundation.org/Getting_Started_With_Contributing'),
           discourse_link: link_to(t('.discourse_link_text'), 'https://discourse.diasporafoundation.org/'),
+          mailing_list_link: link_to(t('.discourse_link_text'), 'https://discourse.diasporafoundation.org/'),
           irc_link: link_to(t('.irc_link_text'), 'http://webchat.freenode.net/?channels=diaspora-dev')
         ).html_safe %>
       </p>


### PR DESCRIPTION
As a temporary fix, I've reverted the link name from `discourse_link` to `mailing_list_link`. While it's not an ideal name for a link to Discourse, at least it will fix the broken translations for now.

As before, I've not been able to test this because my instance is broken. But I felt obliged to try to fix it as I broke it.

@SuperTux88 @denschub would be grateful if one of you would check this out and push it when you get a chance.